### PR TITLE
Add logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -117,6 +117,7 @@ module.exports = {
       },
       rules: {
         // '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/unbound-method': 'off',
         'import/no-extraneous-dependencies': [
           'error',
           {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,7 +109,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.spec.{js,ts}', '*.spec.tsx'],
+      files: ['*.spec.{js,ts}', '*.spec.tsx', 'e2e/**'],
       plugins: ['testing-library', 'jest-dom'],
       extends: ['plugin:testing-library/react', 'plugin:jest-dom/recommended'],
       env: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
   },
   plugins: ['prettier', '@typescript-eslint'],
   rules: {
+    'no-console': 'error',
     'react/prop-types': 'off',
     'import/prefer-default-export': 'off',
     '@typescript-eslint/no-unused-vars': 'off',

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:slim
+FROM node:12-slim
 
 WORKDIR /app
 

--- a/client/components/Button/index.tsx
+++ b/client/components/Button/index.tsx
@@ -4,7 +4,7 @@ const Button: React.FC = ({ children }) => (
   <button
     type="button"
     onClick={() => {
-      window.eApi.openGithub();
+      window.bridge.test();
     }}
   >
     {children}

--- a/client/components/Greetings/index.tsx
+++ b/client/components/Greetings/index.tsx
@@ -12,7 +12,7 @@ const Greetings: React.FC = () => (
     <Text>
       An Electron boilerplate including TypeScript, React, Jest and ESLint.
     </Text>
-    <Button>I am the button</Button>
+    <Button>Test Button</Button>
   </Container>
 );
 

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -1,7 +1,7 @@
-import { IEApi } from '@shared/eApi';
+import { IBridge } from '@shared/IBridge';
 
 declare global {
   interface Window {
-    eApi: IEApi;
+    bridge: IBridge;
   }
 }

--- a/e2e/stubbed/init.ts
+++ b/e2e/stubbed/init.ts
@@ -1,0 +1,20 @@
+import { Application } from 'spectron';
+import { join } from 'path';
+
+export const app = new Application({
+  path: 'node_modules/.bin/electron',
+  args: [
+    // this points to the project root to find the package.json
+    // the `main` entry is then used
+    join(__dirname, '../..'),
+    // this seems to be required to run in headless mode
+    // have raised #36 to investigate
+    '--no-sandbox',
+  ],
+  requireName: 'electronRequire',
+  env: {
+    // enables certain features such as nodeIntegration to allow spectron to
+    // hook into the running electron process
+    INTEGRATION: true,
+  },
+});

--- a/e2e/stubbed/integration.spec.ts
+++ b/e2e/stubbed/integration.spec.ts
@@ -16,7 +16,7 @@ describe('stubbed integration tests', () => {
     env: {
       // enables certain features such as nodeIntegration to allow spectron to
       // hook into the running electron process
-      E2E_TESTS: true,
+      INTEGRATION: true,
     },
   });
 

--- a/e2e/stubbed/integration.spec.ts
+++ b/e2e/stubbed/integration.spec.ts
@@ -4,14 +4,33 @@ import { join } from 'path';
 describe('stubbed integration tests', () => {
   const app = new Application({
     path: 'node_modules/.bin/electron',
-    args: [join(__dirname, '../..'), '--no-sandbox'],
+    args: [
+      // this points to the project root to find the package.json
+      // the `main` entry is then used
+      join(__dirname, '../..'),
+      // this seems to be required to run in headless mode
+      // have raised #36 to investigate
+      '--no-sandbox',
+    ],
+    requireName: 'electronRequire',
+    env: {
+      // enables certain features such as nodeIntegration to allow spectron to
+      // hook into the running electron process
+      E2E_TESTS: true,
+    },
   });
 
   beforeEach(async () => {
-    await app.start();
+    if (app.isRunning()) {
+      await app.restart();
+    } else {
+      await app.start();
+    }
+    // play around with this, but too fast (500) seemed to stop the window closing
+    // await app.client.setTimeout({ implicit: 1500 });
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     if (app.isRunning()) {
       await app.stop();
     }
@@ -20,5 +39,10 @@ describe('stubbed integration tests', () => {
   it('opens an app with a window', async () => {
     const title = await app.client.getTitle();
     expect(title).toBe('Pancake');
+  });
+
+  it('bridge event from client is logged by electron', async () => {
+    const button = await app.client.$('button=Test Button');
+    expect(await button.getText()).toBe('Test Button');
   });
 });

--- a/e2e/stubbed/integration.spec.ts
+++ b/e2e/stubbed/integration.spec.ts
@@ -45,5 +45,9 @@ describe('stubbed integration tests', () => {
   it('bridge event from client is logged by electron', async () => {
     const button = await app.client.$('button=Test Button');
     expect(await button.getText()).toBe('Test Button');
+    await button.click();
+    const logs = await app.client.getMainProcessLogs();
+    const [clickLog] = logs.reverse();
+    expect(clickLog).toContain('test message');
   });
 });

--- a/electron/AppUpdater.ts
+++ b/electron/AppUpdater.ts
@@ -1,8 +1,0 @@
-import log from 'electron-log';
-import { autoUpdater } from 'electron-updater';
-
-export function checkForUpdates(): void {
-  log.transports.file.level = 'debug';
-  autoUpdater.logger = log;
-  autoUpdater.checkForUpdatesAndNotify().catch((err) => log.error(err));
-}

--- a/electron/__mocks__/electron-devtools-installer.ts
+++ b/electron/__mocks__/electron-devtools-installer.ts
@@ -1,0 +1,14 @@
+import type { ExtensionReference } from 'electron-devtools-installer';
+
+const installer = jest.fn<Promise<string>, ExtensionReference[]>(
+  async (extension) => Promise.resolve(extension.id)
+);
+
+export default installer;
+
+const REACT_DEVELOPER_TOOLS: ExtensionReference = {
+  electron: '',
+  id: 'react-tools',
+};
+
+export { REACT_DEVELOPER_TOOLS };

--- a/electron/__mocks__/electron-updater.ts
+++ b/electron/__mocks__/electron-updater.ts
@@ -1,0 +1,6 @@
+const autoUpdater = {
+  logger: null,
+  checkForUpdatesAndNotify: jest.fn().mockResolvedValue(null),
+};
+
+export { autoUpdater };

--- a/electron/__mocks__/electron.ts
+++ b/electron/__mocks__/electron.ts
@@ -1,0 +1,9 @@
+export const app = {
+  getName: jest.fn(),
+  getVersion: jest.fn(),
+  quit: jest.fn(),
+};
+
+export const dialog = {
+  showMessageBox: jest.fn().mockResolvedValue(null),
+};

--- a/electron/createWindow.ts
+++ b/electron/createWindow.ts
@@ -25,7 +25,7 @@ export function createWindow(logger: ILogger): BrowserWindow {
         contextIsolation: true,
       };
 
-  logger.info(secureEnvs);
+  logger.debug(secureEnvs);
 
   const mainWindow = new BrowserWindow({
     width: 1100,
@@ -43,7 +43,7 @@ export function createWindow(logger: ILogger): BrowserWindow {
 
     mainWindow
       .loadURL('http://localhost:4000')
-      .catch((err) => logger.error(err));
+      .catch(logger.errorWithContext('loading window from dev server'));
   } else {
     mainWindow
       .loadURL(
@@ -53,7 +53,7 @@ export function createWindow(logger: ILogger): BrowserWindow {
           slashes: true,
         })
       )
-      .catch((err) => logger.error(err));
+      .catch(logger.errorWithContext('loading window from file'));
   }
 
   mainWindow.webContents.on('did-finish-load', () => {

--- a/electron/createWindow.ts
+++ b/electron/createWindow.ts
@@ -1,0 +1,64 @@
+import { BrowserWindow } from 'electron';
+import path from 'path';
+import url from 'url';
+import { isDev, isIntegration } from '@shared/constants';
+import { ILogger } from './services';
+
+export function createWindow(logger: ILogger): BrowserWindow {
+  /**
+   * These options should be off in production and dev mode
+   * They are only required for e2e testing with Spectron
+   *
+   * enableRemoteModule needs to be true to allow spectron to access information
+   * about the running electron process
+   *
+   * contextIsolation needs to be disabled to give the browserWindow access to
+   * require, which in turn is used to access `remote` as needed above
+   */
+  const secureEnvs = isIntegration
+    ? {
+        enableRemoteModule: true,
+        contextIsolation: false,
+      }
+    : {
+        enableRemoteModule: false,
+        contextIsolation: true,
+      };
+
+  logger.info(secureEnvs);
+
+  const mainWindow = new BrowserWindow({
+    width: 1100,
+    height: 700,
+    backgroundColor: '#191622',
+    webPreferences: {
+      ...secureEnvs,
+      nodeIntegration: false,
+      preload: path.join(__dirname, './preload.js'),
+    },
+  });
+
+  if (isDev) {
+    mainWindow.webContents.openDevTools();
+
+    mainWindow
+      .loadURL('http://localhost:4000')
+      .catch((err) => logger.error(err));
+  } else {
+    mainWindow
+      .loadURL(
+        url.format({
+          pathname: path.join(__dirname, 'renderer/index.html'),
+          protocol: 'file:',
+          slashes: true,
+        })
+      )
+      .catch((err) => logger.error(err));
+  }
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow.setTitle('Pancake');
+  });
+
+  return mainWindow;
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,11 +1,58 @@
-import { contextBridge, shell } from 'electron';
-import { IEApi } from '@shared/eApi';
+import { contextBridge, ipcRenderer } from 'electron';
+import type { IBridge } from '@shared/IBridge';
+import { isIntegration } from '@shared/constants';
 
-const eApi: IEApi = {
-  openGithub: () => {
-    shell
-      .openExternal('https://github.com/settings/tokens/new')
-      .catch(console.error);
+const bridge: IBridge = {
+  test: () => {
+    ipcRenderer.send('bridge', 'test message');
+    // shell.openExternal('https://github.com/settings/tokens/new').catch((e) => {
+    //   ipcRenderer.send('unexpectedError', e);
+    // });
   },
 };
-contextBridge.exposeInMainWorld('eApi', eApi);
+
+/**
+ * Integration is required for e2e testing with Spectron
+ *
+ * the contextBridge prevents the client access `require` which is desirable in most situations
+ * however spectron needs access to the `remote` module via `require`, so we have to
+ * bypass this security feature for this scenario
+ */
+if (isIntegration) {
+  // this mimics the behaviour of the context bridge to keep behaviour as prod-like as possible
+  deepFreeze(bridge);
+
+  window.bridge = bridge;
+
+  // eval('require') here stops webpack trying to work out what's being imported
+  // this removes some warnings and prevents `require` becoming webpack's own
+  // `_webpack_require`, which seemed to keep failing
+
+  // @ts-expect-error just for spectron to have access to running electron
+  // eslint-disable-next-line no-eval,@typescript-eslint/no-unsafe-assignment
+  window.electronRequire = eval('require');
+} else {
+  contextBridge.exposeInMainWorld('bridge', bridge);
+}
+/**
+ * Recursively Object.freeze() on objects and functions
+ * @see https://github.com/substack/deep-freeze
+ * @param o Object on which to lock the attributes
+ */
+function deepFreeze<T extends Record<string, any>>(o: T): Readonly<T> { // eslint-disable-line
+  Object.freeze(o);
+
+  Object.getOwnPropertyNames(o).forEach((prop) => {
+    if (
+      // eslint-disable-next-line no-prototype-builtins
+      o.hasOwnProperty(prop) &&
+      o[prop] !== null &&
+      (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
+      !Object.isFrozen(o[prop])
+    ) {
+      deepFreeze(o[prop]);
+    }
+  });
+
+  return o;
+}

--- a/electron/services/devTools/devTools.spec.ts
+++ b/electron/services/devTools/devTools.spec.ts
@@ -1,0 +1,56 @@
+import _installExtension, {
+  REACT_DEVELOPER_TOOLS,
+} from 'electron-devtools-installer';
+import { mocked } from 'ts-jest/utils';
+import * as _constants from '@shared/constants';
+import { setUpDevtools } from '.';
+import { logger } from '../logger';
+
+jest.mock('../logger');
+jest.mock('@shared/constants');
+const constants = mocked(_constants, true);
+const installExtension = mocked(_installExtension);
+
+describe('Devtools service', () => {
+  beforeEach(() => {
+    setUpDevtools(logger)();
+  });
+
+  describe('when in development', () => {
+    beforeAll(() => {
+      constants.isDev = true;
+    });
+
+    it('it installs extensions', () => {
+      expect(installExtension).toHaveBeenCalledWith(REACT_DEVELOPER_TOOLS);
+    });
+
+    it('logs installation', () => {
+      expect(logger.info).toHaveBeenCalledWith(
+        `Added Extension: "${REACT_DEVELOPER_TOOLS.id}"`
+      );
+    });
+
+    describe('when there is an error', () => {
+      const err = new Error('poop');
+
+      beforeAll(() => {
+        installExtension.mockRejectedValue(err);
+      });
+
+      it('it logs the error', () => {
+        expect(logger.errorWithContext('')).toHaveBeenCalledWith(err);
+      });
+    });
+  });
+
+  describe('when not in development', () => {
+    beforeAll(() => {
+      constants.isDev = false;
+    });
+
+    it('does not install extensions', () => {
+      expect(installExtension).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/services/devTools/devTools.spec.ts
+++ b/electron/services/devTools/devTools.spec.ts
@@ -3,8 +3,8 @@ import _installExtension, {
 } from 'electron-devtools-installer';
 import { mocked } from 'ts-jest/utils';
 import * as _constants from '@shared/constants';
-import { setUpDevtools } from '.';
 import { logger } from '../logger';
+import { setUpDevtools } from './devTools';
 
 jest.mock('../logger');
 jest.mock('@shared/constants');

--- a/electron/services/devTools/devTools.ts
+++ b/electron/services/devTools/devTools.ts
@@ -1,0 +1,17 @@
+import { isDev } from '@shared/constants';
+import installExtension, {
+  REACT_DEVELOPER_TOOLS,
+} from 'electron-devtools-installer';
+import { ILogger } from '../logger';
+
+export function setUpDevtools(logger: ILogger) {
+  return (): void => {
+    if (isDev) {
+      installExtension(REACT_DEVELOPER_TOOLS)
+        .then((name) => {
+          logger.info(`Added Extension: "${name}"`);
+        })
+        .catch(logger.errorWithContext('installing extension'));
+    }
+  };
+}

--- a/electron/services/devTools/index.ts
+++ b/electron/services/devTools/index.ts
@@ -1,17 +1,1 @@
-import installExtension, {
-  REACT_DEVELOPER_TOOLS,
-} from 'electron-devtools-installer';
-import { isDev } from '@shared/constants';
-import type { ILogger } from '..';
-
-export function setUpDevtools(logger: ILogger) {
-  return (): void => {
-    if (isDev) {
-      installExtension(REACT_DEVELOPER_TOOLS)
-        .then((name) => {
-          logger.info(`Added Extension: "${name}"`);
-        })
-        .catch(logger.errorWithContext('installing extension'));
-    }
-  };
-}
+export { setUpDevtools } from './devTools';

--- a/electron/services/devTools/index.ts
+++ b/electron/services/devTools/index.ts
@@ -1,0 +1,17 @@
+import installExtension, {
+  REACT_DEVELOPER_TOOLS,
+} from 'electron-devtools-installer';
+import { isDev } from '@shared/constants';
+import type { ILogger } from '..';
+
+export function setUpDevtools(logger: ILogger) {
+  return (): void => {
+    if (isDev) {
+      installExtension(REACT_DEVELOPER_TOOLS)
+        .then((name) => {
+          logger.info(`Added Extension: "${name}"`);
+        })
+        .catch(logger.errorWithContext('installing extension'));
+    }
+  };
+}

--- a/electron/services/index.ts
+++ b/electron/services/index.ts
@@ -1,0 +1,1 @@
+export * from './logger';

--- a/electron/services/index.ts
+++ b/electron/services/index.ts
@@ -1,1 +1,3 @@
 export * from './logger';
+export * from './updater';
+export * from './devTools';

--- a/electron/services/logger/__mocks__/index.ts
+++ b/electron/services/logger/__mocks__/index.ts
@@ -1,5 +1,7 @@
 import type { ILogger } from '..';
 
+jest.mock('electron-log');
+
 const { logger } = jest.genMockFromModule<{ logger: ILogger }>('..');
 
 const spy = jest.fn();

--- a/electron/services/logger/__mocks__/index.ts
+++ b/electron/services/logger/__mocks__/index.ts
@@ -1,0 +1,8 @@
+import type { ILogger } from '..';
+
+const { logger } = jest.genMockFromModule<{ logger: ILogger }>('..');
+
+const spy = jest.fn();
+logger.errorWithContext = jest.fn().mockReturnValue(spy);
+
+export { logger };

--- a/electron/services/logger/__snapshots__/errorHandler.spec.ts.snap
+++ b/electron/services/logger/__snapshots__/errorHandler.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`errorHandler when the user choses to report the error and all details are provided by electron opens a github issue 1`] = `
+exports[`errorHandler when the user chooses to report the error and all details are provided by electron opens a github issue 1`] = `
 Array [
   "https://github.com/AHDesigns/pancake-electron/issues/new",
   Object {
@@ -22,7 +22,7 @@ pancake",
 ]
 `;
 
-exports[`errorHandler when the user choses to report the error and no details are provided by electron opens a github issue 1`] = `
+exports[`errorHandler when the user chooses to report the error and no details are provided by electron opens a github issue 1`] = `
 Array [
   "https://github.com/AHDesigns/pancake-electron/issues/new",
   Object {
@@ -44,7 +44,7 @@ no app version",
 ]
 `;
 
-exports[`errorHandler when the user choses to report the error and no stack trace is provided opens a github issue 1`] = `
+exports[`errorHandler when the user chooses to report the error and no stack trace is provided opens a github issue 1`] = `
 Array [
   "https://github.com/AHDesigns/pancake-electron/issues/new",
   Object {

--- a/electron/services/logger/__snapshots__/errorHandler.spec.ts.snap
+++ b/electron/services/logger/__snapshots__/errorHandler.spec.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`errorHandler when the user choses to report the error and all details are provided by electron opens a github issue 1`] = `
+Array [
+  "https://github.com/AHDesigns/pancake-electron/issues/new",
+  Object {
+    "body": "**Describe the bug**
+Describe as best you can when the error occured, with steps leading up to it if possible.
+**Screenshots**
+If possible, add screenshots to help explain your problem.
+**Error Report:**
+Stacktrace: 
+\`\`\`
+error stack for poop
+\`\`\`
+OS: mac
+1
+pancake",
+    "labels": "to refine, bug",
+    "title": "Error report",
+  },
+]
+`;
+
+exports[`errorHandler when the user choses to report the error and no details are provided by electron opens a github issue 1`] = `
+Array [
+  "https://github.com/AHDesigns/pancake-electron/issues/new",
+  Object {
+    "body": "**Describe the bug**
+Describe as best you can when the error occured, with steps leading up to it if possible.
+**Screenshots**
+If possible, add screenshots to help explain your problem.
+**Error Report:**
+Stacktrace: 
+\`\`\`
+error stack for poop
+\`\`\`
+OS: no OS detected
+no electron version
+no app version",
+    "labels": "to refine, bug",
+    "title": "Error report",
+  },
+]
+`;
+
+exports[`errorHandler when the user choses to report the error and no stack trace is provided opens a github issue 1`] = `
+Array [
+  "https://github.com/AHDesigns/pancake-electron/issues/new",
+  Object {
+    "body": "**Describe the bug**
+Describe as best you can when the error occured, with steps leading up to it if possible.
+**Screenshots**
+If possible, add screenshots to help explain your problem.
+**Error Report:**
+No stacktrace
+OS: no OS detected
+no electron version
+no app version",
+    "labels": "to refine, bug",
+    "title": "Error report",
+  },
+]
+`;

--- a/electron/services/logger/createLogger.spec.ts
+++ b/electron/services/logger/createLogger.spec.ts
@@ -29,4 +29,18 @@ describe('createLogger', () => {
       onError: loggerErrorHandler,
     });
   });
+
+  it('logs the initialised state', () => {
+    expect(log.info).toHaveBeenCalledWith(
+      expect.any(String),
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+      expect.objectContaining({
+        integration: false,
+        env: 'test',
+        file: expect.any(String),
+        console: expect.any(String),
+      })
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    );
+  });
 });

--- a/electron/services/logger/createLogger.spec.ts
+++ b/electron/services/logger/createLogger.spec.ts
@@ -1,0 +1,32 @@
+import _log from 'electron-log';
+import { mocked } from 'ts-jest/utils';
+import { createLogger, ILogger, loggerErrorHandler } from './createLogger';
+
+jest.mock('electron-log');
+const log = mocked(_log, true);
+
+describe('createLogger', () => {
+  const error = new Error('poop');
+  let logger: ILogger;
+
+  beforeEach(() => {
+    logger = createLogger(_log);
+  });
+
+  it('sets transport correctly', () => {
+    expect(log.transports.file.level).toBe('info');
+    expect(log.transports.console.level).toBe('silly');
+  });
+
+  it('errorWithContext logs errors', () => {
+    logger.errorWithContext('context')(error);
+    expect(log.error).toHaveBeenCalledWith('context', error);
+  });
+
+  it('sets up uncaught error handler', () => {
+    expect(log.catchErrors).toHaveBeenCalledWith({
+      showDialog: false,
+      onError: loggerErrorHandler,
+    });
+  });
+});

--- a/electron/services/logger/createLogger.spec.ts
+++ b/electron/services/logger/createLogger.spec.ts
@@ -30,6 +30,8 @@ describe('createLogger', () => {
     { nodenv: 'development', fileLevel: false, consoleLevel: 'silly' },
     { nodenv: 'test', fileLevel: false, consoleLevel: 'silly' },
     { nodenv: 'production', fileLevel: 'info', consoleLevel: false },
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    { nodenv: 'impossible' as Nodenv, fileLevel: 'info', consoleLevel: 'info' },
   ];
 
   logLevels.forEach(({ nodenv, consoleLevel, fileLevel }) => {
@@ -80,14 +82,7 @@ describe('createLogger', () => {
   it('logs the initialised state', () => {
     expect(log.info).toHaveBeenCalledWith(
       expect.any(String),
-      /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-      expect.objectContaining({
-        integration: false,
-        env: 'test',
-        file: false,
-        console: 'silly',
-      })
-      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+      expect.any(String)
     );
   });
 });

--- a/electron/services/logger/createLogger.ts
+++ b/electron/services/logger/createLogger.ts
@@ -1,0 +1,34 @@
+import { ElectronLog } from 'electron-log';
+import { errorHandler } from './errorHandler';
+
+// eslint-disable-next-line import/no-mutable-exports
+export let loggerErrorHandler: ReturnType<typeof errorHandler>;
+
+export interface ILogger extends ElectronLog {
+  errorWithContext(context: string): (err: Error) => void;
+}
+
+export function createLogger(log: ElectronLog): ILogger {
+  // eslint-disable-next-line no-param-reassign
+  log.transports.file.level = 'info';
+  // eslint-disable-next-line no-param-reassign
+  log.transports.console.level = 'silly';
+
+  const logger: ILogger = {
+    ...log,
+    errorWithContext(context: string) {
+      return (err: Error) => {
+        log.error(context, err);
+      };
+    },
+  };
+
+  loggerErrorHandler = errorHandler(logger);
+
+  log.catchErrors({
+    showDialog: false,
+    onError: loggerErrorHandler,
+  });
+
+  return logger;
+}

--- a/electron/services/logger/createLogger.ts
+++ b/electron/services/logger/createLogger.ts
@@ -1,4 +1,5 @@
 import { ElectronLog } from 'electron-log';
+import { isIntegration, nodenv } from '@shared/constants';
 import { errorHandler } from './errorHandler';
 
 // eslint-disable-next-line import/no-mutable-exports
@@ -28,6 +29,13 @@ export function createLogger(log: ElectronLog): ILogger {
   log.catchErrors({
     showDialog: false,
     onError: loggerErrorHandler,
+  });
+
+  logger.info('Logger initialised', {
+    env: nodenv,
+    integration: isIntegration,
+    file: log.transports.file.level,
+    console: log.transports.console.level,
   });
 
   return logger;

--- a/electron/services/logger/errorHandler.spec.ts
+++ b/electron/services/logger/errorHandler.spec.ts
@@ -11,7 +11,7 @@ describe('errorHandler', () => {
   error.stack = 'error stack for poop';
   const defaultVersions = { os: 'mac', electron: '1', app: 'pancake' };
   let versions: typeof defaultVersions | undefined;
-  const submitIssue = jest.fn();
+  let submitIssue: jest.Mock | undefined = jest.fn();
 
   beforeEach(() => {
     const appliedErrorHandler = errorHandler(logger);
@@ -43,7 +43,7 @@ describe('errorHandler', () => {
     });
   });
 
-  describe('when the user choses to quit', () => {
+  describe('when the user chooses to quit', () => {
     beforeAll(() => {
       dialog.showMessageBox.mockResolvedValue({
         response: 2,
@@ -61,7 +61,7 @@ describe('errorHandler', () => {
     });
   });
 
-  describe('when the user choses to report the error', () => {
+  describe('when the user chooses to report the error', () => {
     beforeAll(() => {
       dialog.showMessageBox.mockResolvedValue({
         response: 1,
@@ -90,7 +90,7 @@ describe('errorHandler', () => {
           }
           /* eslint-enable @typescript-eslint/no-unsafe-assignment */
         );
-        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+        expect(submitIssue?.mock.calls[0]).toMatchSnapshot();
       });
     });
 
@@ -110,7 +110,7 @@ describe('errorHandler', () => {
           }
           /* eslint-enable @typescript-eslint/no-unsafe-assignment */
         );
-        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+        expect(submitIssue?.mock.calls[0]).toMatchSnapshot();
       });
     });
 
@@ -131,7 +131,22 @@ describe('errorHandler', () => {
           }
           /* eslint-enable @typescript-eslint/no-unsafe-assignment */
         );
-        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+        expect(submitIssue?.mock.calls[0]).toMatchSnapshot();
+      });
+    });
+
+    describe('when no submit function is provided', () => {
+      beforeAll(() => {
+        submitIssue = undefined;
+      });
+
+      it('does nothing', () => {
+        expect(app.quit).not.toHaveBeenCalled();
+        expect(logger.errorWithContext('')).not.toHaveBeenCalled();
+      });
+
+      afterAll(() => {
+        submitIssue = jest.fn();
       });
     });
 

--- a/electron/services/logger/errorHandler.spec.ts
+++ b/electron/services/logger/errorHandler.spec.ts
@@ -1,0 +1,153 @@
+import * as electron from 'electron';
+import { mocked } from 'ts-jest/utils';
+import { logger } from './index';
+import { errorHandler } from './errorHandler';
+
+jest.mock('./index');
+const { app, dialog } = mocked(electron, true);
+
+describe('errorHandler', () => {
+  const error = new Error('poop');
+  error.stack = 'error stack for poop';
+  const defaultVersions = { os: 'mac', electron: '1', app: 'pancake' };
+  let versions: typeof defaultVersions | undefined;
+  const submitIssue = jest.fn();
+
+  beforeEach(() => {
+    const appliedErrorHandler = errorHandler(logger);
+    appliedErrorHandler?.(error, versions, submitIssue);
+  });
+
+  it('creates a message box for the user', () => {
+    expect(dialog.showMessageBox).toHaveBeenCalledWith({
+      title: 'An error occurred',
+      message: error.message,
+      detail: error.stack,
+      type: 'error',
+      buttons: ['Ignore', 'Report', 'Exit'],
+    });
+  });
+
+  describe('when the user chooses to ignore the error', () => {
+    beforeAll(() => {
+      dialog.showMessageBox.mockResolvedValue({
+        response: 3,
+        checkboxChecked: false,
+      });
+    });
+
+    it('does nothing', () => {
+      expect(submitIssue).not.toHaveBeenCalled();
+      expect(app.quit).not.toHaveBeenCalled();
+      expect(logger.errorWithContext('')).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the user choses to quit', () => {
+    beforeAll(() => {
+      dialog.showMessageBox.mockResolvedValue({
+        response: 2,
+        checkboxChecked: false,
+      });
+    });
+
+    it('does not log a report', () => {
+      expect(submitIssue).not.toHaveBeenCalled();
+      expect(logger.errorWithContext('')).not.toHaveBeenCalled();
+    });
+
+    it('quits the app', () => {
+      expect(app.quit).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the user choses to report the error', () => {
+    beforeAll(() => {
+      dialog.showMessageBox.mockResolvedValue({
+        response: 1,
+        checkboxChecked: false,
+      });
+    });
+
+    it('does not quit the app', () => {
+      expect(logger.errorWithContext('')).not.toHaveBeenCalled();
+      expect(app.quit).not.toHaveBeenCalled();
+    });
+
+    describe('and all details are provided by electron', () => {
+      beforeAll(() => {
+        versions = defaultVersions;
+      });
+
+      it('opens a github issue', () => {
+        expect(submitIssue).toHaveBeenCalledWith(
+          'https://github.com/AHDesigns/pancake-electron/issues/new',
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+          {
+            title: expect.any(String),
+            body: expect.any(String),
+            labels: 'to refine, bug',
+          }
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        );
+        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+      });
+    });
+
+    describe('and no details are provided by electron', () => {
+      beforeAll(() => {
+        versions = undefined;
+      });
+
+      it('opens a github issue', () => {
+        expect(submitIssue).toHaveBeenCalledWith(
+          'https://github.com/AHDesigns/pancake-electron/issues/new',
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+          {
+            title: expect.any(String),
+            body: expect.any(String),
+            labels: 'to refine, bug',
+          }
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        );
+        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+      });
+    });
+
+    describe('and no stack trace is provided', () => {
+      beforeAll(() => {
+        versions = undefined;
+        error.stack = undefined;
+      });
+
+      it('opens a github issue', () => {
+        expect(submitIssue).toHaveBeenCalledWith(
+          'https://github.com/AHDesigns/pancake-electron/issues/new',
+          /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+          {
+            title: expect.any(String),
+            body: expect.stringContaining('No stacktrace'),
+            labels: 'to refine, bug',
+          }
+          /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        );
+        expect(submitIssue.mock.calls[0]).toMatchSnapshot();
+      });
+    });
+
+    describe('when submit issue fails', () => {
+      const err = new Error('poop');
+      beforeAll(() => {
+        dialog.showMessageBox.mockRejectedValue(err);
+      });
+
+      it('does not quit', () => {
+        expect(app.quit).not.toHaveBeenCalled();
+      });
+
+      it('logs the exception', () => {
+        expect(logger.errorWithContext('')).toHaveBeenCalledWith(err);
+      });
+    });
+  });
+});

--- a/electron/services/logger/errorHandler.ts
+++ b/electron/services/logger/errorHandler.ts
@@ -1,6 +1,6 @@
 import { app, dialog } from 'electron';
 import { CatchErrorsOptions } from 'electron-log';
-import { ILogger } from '.';
+import type { ILogger } from './createLogger';
 
 export const errorHandler: (
   logger: ILogger

--- a/electron/services/logger/errorHandler.ts
+++ b/electron/services/logger/errorHandler.ts
@@ -1,0 +1,67 @@
+import { app, dialog } from 'electron';
+import { CatchErrorsOptions } from 'electron-log';
+import { ILogger } from '.';
+
+export const errorHandler: (
+  logger: ILogger
+) => CatchErrorsOptions['onError'] = (logger) => (
+  error,
+  versions,
+  submitIssue
+) => {
+  dialog
+    .showMessageBox({
+      title: 'An error occurred',
+      message: error.message,
+      detail: error.stack,
+      type: 'error',
+      buttons: ['Ignore', 'Report', 'Exit'],
+    })
+    .then((result) => {
+      if (result.response === 1) {
+        const body = generateReport(error, versions);
+
+        submitIssue?.(
+          'https://github.com/AHDesigns/pancake-electron/issues/new',
+          {
+            title: 'Error report',
+            body,
+            labels: 'to refine, bug',
+          }
+        );
+        return;
+      }
+      if (result.response === 2) {
+        app.quit();
+      }
+    })
+    .catch(logger.errorWithContext('error submitting issue'));
+};
+
+function generateReport(
+  error: Error,
+  versions?: {
+    os: string;
+    electron: string;
+    app: string;
+  }
+): string {
+  const appVersion = versions?.app ?? 'no app version';
+  const electron = versions?.electron ?? 'no electron version';
+  const os = versions?.os ?? 'no OS detected';
+  const code = '```';
+  const heading = '**Error Report:**';
+  const stack = error.stack
+    ? `Stacktrace: \n${code}\n${error.stack}\n${code}`
+    : 'No stacktrace';
+
+  return `**Describe the bug**
+Describe as best you can when the error occured, with steps leading up to it if possible.
+**Screenshots**
+If possible, add screenshots to help explain your problem.
+${heading}
+${stack}
+OS: ${os}
+${electron}
+${appVersion}`;
+}

--- a/electron/services/logger/index.ts
+++ b/electron/services/logger/index.ts
@@ -1,2 +1,2 @@
+export type { ILogger } from './createLogger';
 export { logger } from './logger';
-export { ILogger } from './createLogger';

--- a/electron/services/logger/index.ts
+++ b/electron/services/logger/index.ts
@@ -1,0 +1,2 @@
+export { logger } from './logger';
+export { ILogger } from './createLogger';

--- a/electron/services/logger/logger.ts
+++ b/electron/services/logger/logger.ts
@@ -1,0 +1,4 @@
+import log from 'electron-log';
+import { createLogger } from './createLogger';
+
+export const logger = createLogger(log);

--- a/electron/services/updater/index.ts
+++ b/electron/services/updater/index.ts
@@ -1,9 +1,1 @@
-import { autoUpdater } from 'electron-updater';
-import type { ILogger } from '..';
-
-export function checkForUpdates(logger: ILogger): void {
-  autoUpdater.logger = logger;
-  autoUpdater
-    .checkForUpdatesAndNotify()
-    .catch(logger.errorWithContext('checking for updates'));
-}
+export { checkForUpdates } from './updater';

--- a/electron/services/updater/index.ts
+++ b/electron/services/updater/index.ts
@@ -1,0 +1,9 @@
+import { autoUpdater } from 'electron-updater';
+import type { ILogger } from '..';
+
+export function checkForUpdates(logger: ILogger): void {
+  autoUpdater.logger = logger;
+  autoUpdater
+    .checkForUpdatesAndNotify()
+    .catch(logger.errorWithContext('checking for updates'));
+}

--- a/electron/services/updater/updater.spec.ts
+++ b/electron/services/updater/updater.spec.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 import { autoUpdater as _autoUpdater } from 'electron-updater';
-import { checkForUpdates } from '.';
 import { logger as _logger } from '../logger';
+import { checkForUpdates } from './updater';
 
 const autoUpdater = mocked(_autoUpdater, true);
 

--- a/electron/services/updater/updater.spec.ts
+++ b/electron/services/updater/updater.spec.ts
@@ -1,0 +1,35 @@
+import { mocked } from 'ts-jest/utils';
+import { autoUpdater as _autoUpdater } from 'electron-updater';
+import { checkForUpdates } from '.';
+import { logger as _logger } from '../logger';
+
+const autoUpdater = mocked(_autoUpdater, true);
+
+jest.mock('../logger');
+const logger = mocked(_logger);
+
+describe('checkForUpdates', () => {
+  beforeEach(() => {
+    checkForUpdates(logger);
+  });
+
+  it("sets the updater's logger correctly", () => {
+    expect(autoUpdater.logger).toBe(logger);
+  });
+
+  it('checks for updates', () => {
+    expect(autoUpdater.checkForUpdatesAndNotify).toHaveBeenCalled();
+  });
+
+  describe('when update errors', () => {
+    const err = new Error('poop');
+
+    beforeAll(() => {
+      autoUpdater.checkForUpdatesAndNotify.mockRejectedValue(err);
+    });
+
+    it('catches and logs error', () => {
+      expect(logger.errorWithContext('')).toHaveBeenCalledWith(err);
+    });
+  });
+});

--- a/electron/services/updater/updater.ts
+++ b/electron/services/updater/updater.ts
@@ -1,0 +1,9 @@
+import { autoUpdater } from 'electron-updater';
+import { ILogger } from '../logger';
+
+export function checkForUpdates(logger: ILogger): void {
+  autoUpdater.logger = logger;
+  autoUpdater
+    .checkForUpdatesAndNotify()
+    .catch(logger.errorWithContext('checking for updates'));
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,17 +6,22 @@ const client = './client/**/*.ts?(x)';
 const server = './electron/**/*.ts';
 const shared = './shared/**/*.ts';
 const all = [client, server, shared];
-const escapeHatch = ['!**/github.ts'];
+const escapeHatch = [
+  '!**/index.ts?(x)',
+  '!./electron/main.ts',
+  '!./electron/preload.ts',
+  '!./electron/createWindow.ts',
+];
 module.exports = {
   preset: 'ts-jest',
 
-  collectCoverage: false,
+  collectCoverage: true,
   collectCoverageFrom: all.concat(escapeHatch),
   coverageThreshold: all.reduce(
     (coverage, name) => ({
       ...coverage,
       [name]: {
-        branches: 100,
+        branches: 95,
         functions: 100,
         lines: 100,
         statements: 100,

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@
 const client = './client/**/*.ts?(x)';
 const server = './electron/**/*.ts';
 const shared = './shared/**/*.ts';
-const all = [client, server, shared];
+const all = [server, shared];
 const escapeHatch = [
   '!**/index.ts?(x)',
   '!./electron/main.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 const client = './client/**/*.ts?(x)';
 const server = './electron/**/*.ts';
@@ -28,4 +29,7 @@ module.exports = {
 
   setupFilesAfterEnv: ['./tooling/setupTests.ts'],
   modulePathIgnorePatterns: ['e2e'],
+  moduleNameMapper: {
+    '^@shared(.*)$': '<rootDir>/shared/$1',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "electron": "11.3.0",
     "electron-devtools-installer": "^3.1.0",
-    "electron-log": "^4.3.1",
+    "electron-log": "4.3.2",
     "electron-updater": "^4.3.5",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "run-p dev:*",
     "lint": "eslint .",
     "test": "jest",
-    "e2e": "jest e2e --modulePathIgnorePatterns=''",
+    "e2e": "jest e2e --modulePathIgnorePatterns='' --no-coverage",
     "docker-e2e": "docker build . -f Dockerfile -t pancake",
     "build": "run-p build:*",
     "start": "electron .",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/preset-typescript": "7.13.0",
     "@testing-library/jest-dom": "5.11.9",
     "@testing-library/react": "11.2.5",
-    "@types/electron-devtools-installer": "^2.2.0",
+    "@types/electron-devtools-installer": "2.2.0",
     "@types/jest": "26.0.20",
     "@types/react": "17.0.2",
     "@types/react-dom": "17.0.1",
@@ -65,9 +65,9 @@
   },
   "dependencies": {
     "electron": "11.3.0",
-    "electron-devtools-installer": "^3.1.0",
+    "electron-devtools-installer": "3.1.1",
     "electron-log": "4.3.2",
-    "electron-updater": "^4.3.5",
+    "electron-updater": "4.3.8",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "styled-components": "^5.1.1"

--- a/shared/IBridge.ts
+++ b/shared/IBridge.ts
@@ -1,0 +1,3 @@
+export interface IBridge {
+  test(): void;
+}

--- a/shared/asserts.spec.ts
+++ b/shared/asserts.spec.ts
@@ -1,0 +1,19 @@
+import { assertIsError, assertValidNodenv, validNodenvs } from './asserts';
+
+describe('asserts', () => {
+  test('assertIsError', () => {
+    expect(() => assertIsError('')).toThrowError();
+    expect(() => assertIsError(new Error())).not.toThrowError();
+  });
+
+  test('assertValidNodenv', () => {
+    validNodenvs.forEach((valid) => {
+      expect(() => assertValidNodenv(valid)).not.toThrowError();
+    });
+
+    const invalids = ['', 'squantch', ' '];
+    invalids.forEach((invalid) => {
+      expect(() => assertValidNodenv(invalid)).toThrowError();
+    });
+  });
+});

--- a/shared/asserts.ts
+++ b/shared/asserts.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function assertIsError(err: any): asserts err is Error {
+  if (!(err instanceof Error)) throw err;
+}
+
+export const validNodenvs = ['production', 'development', 'test'] as const;
+
+export type Nodenv = typeof validNodenvs[number];
+
+export function assertValidNodenv(env: string): asserts env is Nodenv {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  if (!validNodenvs.includes(env as Nodenv)) {
+    throw new Error(`node_env of "${env}" is invalid`);
+  }
+}

--- a/shared/constants.spec.ts
+++ b/shared/constants.spec.ts
@@ -1,6 +1,12 @@
 import { Nodenv } from './asserts';
 
+const nodenv = process.env.NODE_ENV;
+
 describe('constants', () => {
+  afterAll(() => {
+    process.env.NODE_ENV = nodenv;
+  });
+
   describe('nodenv', () => {
     const validNodenvs = [
       'test',

--- a/shared/constants.spec.ts
+++ b/shared/constants.spec.ts
@@ -1,0 +1,110 @@
+import { Nodenv } from './asserts';
+
+describe('constants', () => {
+  describe('nodenv', () => {
+    const validNodenvs = [
+      'test',
+      'production',
+      'development',
+      ' development ',
+      '    development    ',
+      '    DEVELOPMENT    ',
+      'DEVELOPMENT',
+      'DevElOPmeNT',
+    ];
+    validNodenvs.forEach((env) => {
+      describe(`when valid nodenv of "${env}"`, () => {
+        it('sets nodenv', () => {
+          jest.resetModules();
+          process.env.NODE_ENV = env;
+          expect(() => {
+            // eslint-disable-next-line global-require
+            require('./constants');
+          }).not.toThrowError();
+        });
+      });
+    });
+
+    const invalidNodenvs = ['', undefined, 'dev', 'true', 'false', ' '];
+
+    invalidNodenvs.forEach((env) => {
+      describe(`when invalid nodenv of "${JSON.stringify(env)}"`, () => {
+        it('throws error', () => {
+          jest.resetModules();
+          process.env.NODE_ENV = env;
+          expect(() => {
+            // eslint-disable-next-line global-require
+            require('./constants');
+          }).toThrowError();
+        });
+      });
+    });
+  });
+
+  describe('isDev, isProd, isTest', () => {
+    interface Collection {
+      env: Nodenv;
+      isProd: boolean;
+      isTest: boolean;
+      isDev: boolean;
+    }
+
+    const collections: Collection[] = [
+      { env: 'development', isProd: false, isTest: false, isDev: true },
+      { env: 'test', isProd: false, isTest: true, isDev: false },
+      { env: 'production', isProd: true, isTest: false, isDev: false },
+    ];
+
+    collections.forEach((collection) => {
+      it(`when env is "${collection.env} env flags are set correctly`, () => {
+        jest.resetModules();
+        process.env.NODE_ENV = collection.env;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, global-require
+        const { isDev, isProd, isTest } = require('./constants');
+        expect(isDev).toBe(collection.isDev);
+        expect(isProd).toBe(collection.isProd);
+        expect(isTest).toBe(collection.isTest);
+      });
+    });
+  });
+
+  describe('isIntegration', () => {
+    describe('when not in production mode', () => {
+      it('is always false', () => {
+        process.env.NODE_ENV = 'development';
+        process.env.INTEGRATION = 'true';
+
+        jest.resetModules();
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, global-require
+        const { isIntegration } = require('./constants');
+        expect(isIntegration).toBe(false);
+      });
+    });
+
+    describe('when in production mode', () => {
+      describe('when INTEGRATION is true', () => {
+        it('is is true', () => {
+          process.env.NODE_ENV = 'production';
+          process.env.INTEGRATION = 'true';
+
+          jest.resetModules();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, global-require
+          const { isIntegration } = require('./constants');
+          expect(isIntegration).toBe(true);
+        });
+      });
+
+      describe('when INTEGRATION is false', () => {
+        it('is is true', () => {
+          process.env.NODE_ENV = 'production';
+          process.env.INTEGRATION = 'false';
+
+          jest.resetModules();
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires, global-require
+          const { isIntegration } = require('./constants');
+          expect(isIntegration).toBe(false);
+        });
+      });
+    });
+  });
+});

--- a/shared/constants.spec.ts
+++ b/shared/constants.spec.ts
@@ -1,10 +1,10 @@
 import { Nodenv } from './asserts';
 
-const nodenv = process.env.NODE_ENV;
+const originalNodenv = process.env.NODE_ENV;
 
 describe('constants', () => {
   afterAll(() => {
-    process.env.NODE_ENV = nodenv;
+    process.env.NODE_ENV = originalNodenv;
   });
 
   describe('nodenv', () => {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -5,7 +5,7 @@ interface URLS {
   readonly main: string;
 }
 
-const nodenv = sanitiseNodenv(process.env.NODE_ENV ?? 'production');
+const nodenv = sanitiseNodenv(process.env.NODE_ENV);
 
 /**
  * Development mode
@@ -37,7 +37,8 @@ const urls: URLS = {
 
 export { nodenv, isDev, isProd, isTest, isIntegration, urls };
 
-function sanitiseNodenv(env: string): Nodenv {
+function sanitiseNodenv(env?: string): Nodenv {
+  if (!env) throw new Error('NODE_ENV is not defined');
   const sanitisedNodenv = env.trim().toLocaleLowerCase();
   assertValidNodenv(sanitisedNodenv);
   return sanitisedNodenv;

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -29,7 +29,7 @@ const isTest = nodenv === 'test';
  * are disabled to allow Spectron to interact with the electron process during
  * e2e tests.
  */
-const isIntegration = isProd && process.env.E2E_TESTS === 'true';
+const isIntegration = isProd && process.env.INTEGRATION === 'true';
 
 const urls: URLS = {
   main: 'http://localhost:4000',

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,0 +1,44 @@
+import type { Nodenv } from './asserts';
+import { assertValidNodenv } from './asserts';
+
+interface URLS {
+  readonly main: string;
+}
+
+const nodenv = sanitiseNodenv(process.env.NODE_ENV ?? 'production');
+
+/**
+ * Development mode
+ * Set for local development, with certain features enabled such as browser devtools
+ */
+const isDev = nodenv === 'development';
+/**
+ * Production mode
+ * Set for how clients will interact with application.
+ */
+const isProd = nodenv === 'production';
+/**
+ * Test mode
+ * Set for Unit tests via Jest
+ * Allows for certain backdoors to be exposed such as forcing errors for testing
+ */
+const isTest = nodenv === 'test';
+/**
+ * Integration mode
+ * Production like in all ways except that certain electron security features
+ * are disabled to allow Spectron to interact with the electron process during
+ * e2e tests.
+ */
+const isIntegration = isProd && process.env.E2E_TESTS === 'true';
+
+const urls: URLS = {
+  main: 'http://localhost:4000',
+};
+
+export { nodenv, isDev, isProd, isTest, isIntegration, urls };
+
+function sanitiseNodenv(env: string): Nodenv {
+  const sanitisedNodenv = env.trim().toLocaleLowerCase();
+  assertValidNodenv(sanitisedNodenv);
+  return sanitisedNodenv;
+}

--- a/shared/eApi.ts
+++ b/shared/eApi.ts
@@ -1,3 +1,0 @@
-export interface IEApi {
-  openGithub(): void;
-}

--- a/tooling/electron.webpack.js
+++ b/tooling/electron.webpack.js
@@ -52,6 +52,7 @@ const main = {
 
 const preload = {
   ...common,
+  devtool: false,
   entry: path.resolve(rootPath, 'electron', 'preload.ts'),
   output: {
     path: path.resolve(rootPath, 'build'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4369,10 +4369,10 @@ electron-devtools-installer@^3.1.0:
     semver "^7.2.1"
     unzip-crx "^0.2.0"
 
-electron-log@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.3.1.tgz#1405fef9d4e6964a5fdb8790a69163aa237ffe91"
-  integrity sha512-S/0CMjYjgyWUsZ3d27VvErPaI5W4oILp4jfeCuN4DhDqrJW6jKRUD2PxFfTdeZEIjM7+fttGg7A61rPcAcZC1w==
+electron-log@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-4.3.2.tgz#213334c69f0498fac677a7a73eae4a61fb69949e"
+  integrity sha512-PJPWE8JDzQ137UlxX9K917nI8GTcwgiJpE2PMPXZo+I6C4AaZU+JWQ3lW5NjQ1Lg8Qk8qbze+Ly0yAiqhbmpeA==
 
 electron-notarize@^0.2.0:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,7 +1669,7 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
-"@types/electron-devtools-installer@^2.2.0":
+"@types/electron-devtools-installer@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@types/electron-devtools-installer/-/electron-devtools-installer-2.2.0.tgz#32ee4ebbe99b3daf9847a6d2097dc00b5de94f10"
   integrity sha512-HJNxpaOXuykCK4rQ6FOMxAA0NLFYsf7FiPFGmab0iQmtVBHSAfxzy3MRFpLTTDDWbV0yD2YsHOQvdu8yCqtCfw==
@@ -1855,7 +1855,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver@^7.3.1":
+"@types/semver@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.4.tgz#43d7168fec6fa0988bb1a513a697b29296721afb"
   integrity sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==
@@ -2488,6 +2488,11 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 aria-query@^4.2.2:
   version "4.2.2"
@@ -3133,12 +3138,12 @@ builder-util-runtime@8.7.1:
     debug "^4.2.0"
     sax "^1.2.4"
 
-builder-util-runtime@8.7.2:
-  version "8.7.2"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.2.tgz#d93afc71428a12789b437e13850e1fa7da956d72"
-  integrity sha512-xBqv+8bg6cfnzAQK1k3OGpfaHg+QkPgIgpEkXNhouZ0WiUkyZCftuRc2LYzQrLucFywpa14Xbc6+hTbpq83yRA==
+builder-util-runtime@8.7.3:
+  version "8.7.3"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz#0aaafa52d25295c939496f62231ca9ff06c30e40"
+  integrity sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==
   dependencies:
-    debug "^4.1.1"
+    debug "^4.3.2"
     sax "^1.2.4"
 
 builder-util@22.7.0:
@@ -3931,6 +3936,13 @@ debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
+  dependencies:
+    ms "2.1.2"
+
 decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -4360,14 +4372,14 @@ electron-chromedriver@^11.0.0:
     "@electron/get" "^1.12.2"
     extract-zip "^2.0.0"
 
-electron-devtools-installer@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.1.0.tgz#c7800d36ab8438b51d2e03345860f817ecb5797f"
-  integrity sha512-qZd1Aoya8YOK6QauNX92V5qyKGtb4lbs238bP+qtMBkXts24xJ/1PtOVBPvdg5w3Ts9L5o6I9sDErKuzHeJFDA==
+electron-devtools-installer@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-3.1.1.tgz#7b56c8c86475c5e4e10de6917d150c53c9ceb55e"
+  integrity sha512-g2D4J6APbpsiIcnLkFMyKZ6bOpEJ0Ltcc2m66F7oKUymyGAt628OWeU9nRZoh1cNmUs/a6Cls2UfOmsZtE496Q==
   dependencies:
     rimraf "^3.0.2"
     semver "^7.2.1"
-    unzip-crx "^0.2.0"
+    unzip-crx-3 "^0.2.0"
 
 electron-log@4.3.2:
   version "4.3.2"
@@ -4401,18 +4413,18 @@ electron-to-chromium@^1.3.649:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.677.tgz#b5d586b0d1976c97cc7e95262677ac5944199513"
   integrity sha512-Tcmk+oKQgpjcM+KYanlkd76ZtpzalkpUULnlJDP6vjHtR7UU564IM9Qv5DxqHZNBQjzXm6mkn7Y8bw2OoE3FmQ==
 
-electron-updater@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-4.3.5.tgz#4fb36f593a031c87ea07ee141c9f064d5deffb15"
-  integrity sha512-5jjN7ebvfj1cLI0VZMdCnJk6aC4bP+dy7ryBf21vArR0JzpRVk0OZHA2QBD+H5rm6ZSeDYHOY6+8PrMEqJ4wlQ==
+electron-updater@4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-4.3.8.tgz#94f1731682a756385726183e2b04b959cb319456"
+  integrity sha512-/tB82Ogb2LqaXrUzAD8waJC+TZV52Pr0Znfj7w+i4D+jA2GgrKFI3Pxjp+36y9FcBMQz7kYsMHcB6c5zBJao+A==
   dependencies:
-    "@types/semver" "^7.3.1"
-    builder-util-runtime "8.7.2"
-    fs-extra "^9.0.1"
-    js-yaml "^3.14.0"
+    "@types/semver" "^7.3.4"
+    builder-util-runtime "8.7.3"
+    fs-extra "^9.1.0"
+    js-yaml "^4.0.0"
     lazy-val "^1.0.4"
     lodash.isequal "^4.5.0"
-    semver "^7.3.2"
+    semver "^7.3.4"
 
 electron@11.3.0:
   version "11.3.0"
@@ -5355,7 +5367,7 @@ fs-extra@^9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
-fs-extra@^9.0.1:
+fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
@@ -6931,6 +6943,13 @@ js-yaml@^3.13.1, js-yaml@^3.14.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -7373,6 +7392,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -9301,6 +9327,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
+semver@^7.3.4:
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"
@@ -10409,10 +10442,10 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-unzip-crx@^0.2.0:
+unzip-crx-3@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.yarnpkg.com/unzip-crx/-/unzip-crx-0.2.0.tgz#4c0baa8bdac756256754beca7843c13d7b858c18"
-  integrity sha1-TAuqi9rHViVnVL7KeEPBPXuFjBg=
+  resolved "https://registry.yarnpkg.com/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz#d5324147b104a8aed9ae8639c95521f6f7cda292"
+  integrity sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==
   dependencies:
     jszip "^3.1.0"
     mkdirp "^0.5.1"
@@ -10971,6 +11004,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@20.x:
   version "20.2.6"


### PR DESCRIPTION
closes #38

- Adds electron-log
- wraps it in an interface and sets up transports based on environment
- basically lots of console logs in dev, and lots of file logs in prod, not the other way around
- beefed up the coverage check
- got integration tests working properly by turning off some security features in INTEGRATION mode only